### PR TITLE
Fix azure-private-dns module validation issues

### DIFF
--- a/azure-private-dns/examples/advanced/main.tf
+++ b/azure-private-dns/examples/advanced/main.tf
@@ -98,12 +98,12 @@ module "private_dns" {
   source = "../../"
 
   # Advanced configuration
-  location                = azurerm_resource_group.example.location
-  resource_group_name     = azurerm_resource_group.example.name
-  create_resource_group   = false
-  private_dns_zone_name   = "corp.internal"
-  environment            = "production"
-  project_name           = "corporate-infrastructure"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  create_resource_group = false
+  private_dns_zone_name = "corp.internal"
+  environment           = "production"
+  project_name          = "corporate-infrastructure"
 
   # Multiple virtual network links
   virtual_network_links = {
@@ -122,11 +122,11 @@ module "private_dns" {
   }
 
   # DNS Resolver configuration
-  enable_dns_resolver              = true
-  dns_resolver_virtual_network_id  = azurerm_virtual_network.hub.id
-  enable_inbound_endpoint          = true
-  enable_outbound_endpoint         = true
-  outbound_endpoint_subnet_id      = azurerm_subnet.dns_outbound.id
+  enable_dns_resolver             = true
+  dns_resolver_virtual_network_id = azurerm_virtual_network.hub.id
+  enable_inbound_endpoint         = true
+  enable_outbound_endpoint        = true
+  outbound_endpoint_subnet_id     = azurerm_subnet.dns_outbound.id
 
   inbound_endpoint_ip_configurations = [
     {
@@ -278,11 +278,11 @@ module "private_dns" {
   }
 
   tags = {
-    Environment   = "Production"
-    Project       = "Corporate-Infrastructure"
-    Example       = "Advanced"
-    CostCenter    = "IT"
-    Owner         = "Platform-Team"
-    Compliance    = "SOC2"
+    Environment = "Production"
+    Project     = "Corporate-Infrastructure"
+    Example     = "Advanced"
+    CostCenter  = "IT"
+    Owner       = "Platform-Team"
+    Compliance  = "SOC2"
   }
 }

--- a/azure-private-dns/examples/advanced/main.tf
+++ b/azure-private-dns/examples/advanced/main.tf
@@ -1,0 +1,288 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.42.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+# Create multiple virtual networks for demonstration
+resource "azurerm_resource_group" "example" {
+  name     = "rg-private-dns-advanced-example"
+  location = "West Europe"
+}
+
+resource "azurerm_virtual_network" "hub" {
+  name                = "vnet-hub"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  tags = {
+    Environment = "Development"
+    Project     = "Private-DNS-Example"
+    Type        = "Hub"
+  }
+}
+
+resource "azurerm_virtual_network" "spoke1" {
+  name                = "vnet-spoke1"
+  address_space       = ["10.1.0.0/16"]
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  tags = {
+    Environment = "Development"
+    Project     = "Private-DNS-Example"
+    Type        = "Spoke1"
+  }
+}
+
+resource "azurerm_virtual_network" "spoke2" {
+  name                = "vnet-spoke2"
+  address_space       = ["10.2.0.0/16"]
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  tags = {
+    Environment = "Development"
+    Project     = "Private-DNS-Example"
+    Type        = "Spoke2"
+  }
+}
+
+# Create subnets for DNS resolver
+resource "azurerm_subnet" "dns_resolver" {
+  name                 = "snet-dns-resolver"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.hub.name
+  address_prefixes     = ["10.0.1.0/24"]
+
+  delegation {
+    name = "dns-resolver-delegation"
+    service_delegation {
+      name = "Microsoft.Network/dnsResolvers"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action"
+      ]
+    }
+  }
+}
+
+resource "azurerm_subnet" "dns_outbound" {
+  name                 = "snet-dns-outbound"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.hub.name
+  address_prefixes     = ["10.0.2.0/24"]
+
+  delegation {
+    name = "dns-outbound-delegation"
+    service_delegation {
+      name = "Microsoft.Network/dnsResolvers"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action"
+      ]
+    }
+  }
+}
+
+# Advanced Private DNS Zone module usage with DNS Resolver
+module "private_dns" {
+  source = "../../"
+
+  # Advanced configuration
+  location                = azurerm_resource_group.example.location
+  resource_group_name     = azurerm_resource_group.example.name
+  create_resource_group   = false
+  private_dns_zone_name   = "corp.internal"
+  environment            = "production"
+  project_name           = "corporate-infrastructure"
+
+  # Multiple virtual network links
+  virtual_network_links = {
+    "hub-vnet" = {
+      virtual_network_id   = azurerm_virtual_network.hub.id
+      registration_enabled = true
+    }
+    "spoke1-vnet" = {
+      virtual_network_id   = azurerm_virtual_network.spoke1.id
+      registration_enabled = false
+    }
+    "spoke2-vnet" = {
+      virtual_network_id   = azurerm_virtual_network.spoke2.id
+      registration_enabled = false
+    }
+  }
+
+  # DNS Resolver configuration
+  enable_dns_resolver              = true
+  dns_resolver_virtual_network_id  = azurerm_virtual_network.hub.id
+  enable_inbound_endpoint          = true
+  enable_outbound_endpoint         = true
+  outbound_endpoint_subnet_id      = azurerm_subnet.dns_outbound.id
+
+  inbound_endpoint_ip_configurations = [
+    {
+      subnet_id                    = azurerm_subnet.dns_resolver.id
+      private_ip_allocation_method = "Dynamic"
+    }
+  ]
+
+  # DNS Forwarding Rules
+  dns_forwarding_rulesets = {
+    "external-dns" = {
+      name = "external-dns-ruleset"
+
+      forwarding_rules = [
+        {
+          name        = "azure-rule"
+          domain_name = "azure.com."
+          target_dns_servers = [
+            {
+              ip_address = "8.8.8.8"
+              port       = 53
+            },
+            {
+              ip_address = "8.8.4.4"
+              port       = 53
+            }
+          ]
+        },
+        {
+          name        = "corporate-rule"
+          domain_name = "corp.external."
+          target_dns_servers = [
+            {
+              ip_address = "192.168.1.10"
+              port       = 53
+            }
+          ]
+        }
+      ]
+
+      virtual_network_links = [
+        {
+          name               = "hub-link"
+          virtual_network_id = azurerm_virtual_network.hub.id
+        },
+        {
+          name               = "spoke1-link"
+          virtual_network_id = azurerm_virtual_network.spoke1.id
+        }
+      ]
+    }
+  }
+
+  # Comprehensive DNS records
+  a_records = {
+    "dc1" = {
+      name    = "dc1"
+      ttl     = 300
+      records = ["10.0.1.10"]
+    }
+    "dc2" = {
+      name    = "dc2"
+      ttl     = 300
+      records = ["10.0.1.11"]
+    }
+    "web-cluster" = {
+      name    = "web-cluster"
+      ttl     = 60
+      records = ["10.1.1.10", "10.1.1.11", "10.1.1.12"]
+    }
+  }
+
+  aaaa_records = {
+    "ipv6-server" = {
+      name    = "ipv6"
+      ttl     = 300
+      records = ["2001:db8::1"]
+    }
+  }
+
+  cname_records = {
+    "www" = {
+      name   = "www"
+      ttl    = 300
+      record = "web-cluster.corp.internal"
+    }
+    "api" = {
+      name   = "api"
+      ttl    = 300
+      record = "web-cluster.corp.internal"
+    }
+  }
+
+  mx_records = {
+    "mail-exchange" = {
+      name = "@"
+      ttl  = 3600
+      records = [
+        {
+          preference = 10
+          exchange   = "mail1.corp.internal"
+        },
+        {
+          preference = 20
+          exchange   = "mail2.corp.internal"
+        }
+      ]
+    }
+  }
+
+  srv_records = {
+    "sip-service" = {
+      name = "_sip._tcp"
+      ttl  = 300
+      records = [
+        {
+          priority = 10
+          weight   = 5
+          port     = 5060
+          target   = "sip1.corp.internal"
+        },
+        {
+          priority = 10
+          weight   = 5
+          port     = 5060
+          target   = "sip2.corp.internal"
+        }
+      ]
+    }
+  }
+
+  txt_records = {
+    "domain-verification" = {
+      name    = "@"
+      ttl     = 300
+      records = ["v=spf1 include:_spf.corp.internal ~all"]
+    }
+    "dkim-selector" = {
+      name    = "selector1._domainkey"
+      ttl     = 300
+      records = ["k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC..."]
+    }
+  }
+
+  # Naming convention
+  naming_convention = {
+    prefix = ["corp"]
+    suffix = ["prod"]
+  }
+
+  tags = {
+    Environment   = "Production"
+    Project       = "Corporate-Infrastructure"
+    Example       = "Advanced"
+    CostCenter    = "IT"
+    Owner         = "Platform-Team"
+    Compliance    = "SOC2"
+  }
+}

--- a/azure-private-dns/examples/advanced/outputs.tf
+++ b/azure-private-dns/examples/advanced/outputs.tf
@@ -8,9 +8,9 @@ output "private_dns_zone_name" {
   value       = module.private_dns.private_dns_zone_name
 }
 
-output "virtual_network_links" {
-  description = "The virtual network links"
-  value       = module.private_dns.virtual_network_links
+output "virtual_network_link_ids" {
+  description = "The virtual network link IDs"
+  value       = module.private_dns.virtual_network_link_ids
 }
 
 output "dns_resolver_id" {
@@ -28,19 +28,19 @@ output "dns_resolver_outbound_endpoint_id" {
   value       = module.private_dns.dns_resolver_outbound_endpoint_id
 }
 
-output "dns_forwarding_rulesets" {
-  description = "The DNS forwarding rulesets"
-  value       = module.private_dns.dns_forwarding_rulesets
+output "dns_forwarding_ruleset_ids" {
+  description = "The DNS forwarding ruleset IDs"
+  value       = module.private_dns.dns_forwarding_ruleset_ids
 }
 
-output "all_dns_records" {
-  description = "All DNS records created"
+output "all_dns_record_ids" {
+  description = "All DNS record IDs created"
   value = {
-    a_records     = module.private_dns.a_records
-    aaaa_records  = module.private_dns.aaaa_records
-    cname_records = module.private_dns.cname_records
-    mx_records    = module.private_dns.mx_records
-    srv_records   = module.private_dns.srv_records
-    txt_records   = module.private_dns.txt_records
+    a_record_ids     = module.private_dns.a_record_ids
+    aaaa_record_ids  = module.private_dns.aaaa_record_ids
+    cname_record_ids = module.private_dns.cname_record_ids
+    mx_record_ids    = module.private_dns.mx_record_ids
+    srv_record_ids   = module.private_dns.srv_record_ids
+    txt_record_ids   = module.private_dns.txt_record_ids
   }
 }

--- a/azure-private-dns/examples/advanced/outputs.tf
+++ b/azure-private-dns/examples/advanced/outputs.tf
@@ -1,0 +1,46 @@
+output "private_dns_zone_id" {
+  description = "The ID of the Private DNS Zone"
+  value       = module.private_dns.private_dns_zone_id
+}
+
+output "private_dns_zone_name" {
+  description = "The name of the Private DNS Zone"
+  value       = module.private_dns.private_dns_zone_name
+}
+
+output "virtual_network_links" {
+  description = "The virtual network links"
+  value       = module.private_dns.virtual_network_links
+}
+
+output "dns_resolver_id" {
+  description = "The ID of the DNS Resolver"
+  value       = module.private_dns.dns_resolver_id
+}
+
+output "dns_resolver_inbound_endpoint_id" {
+  description = "The ID of the DNS Resolver inbound endpoint"
+  value       = module.private_dns.dns_resolver_inbound_endpoint_id
+}
+
+output "dns_resolver_outbound_endpoint_id" {
+  description = "The ID of the DNS Resolver outbound endpoint"
+  value       = module.private_dns.dns_resolver_outbound_endpoint_id
+}
+
+output "dns_forwarding_rulesets" {
+  description = "The DNS forwarding rulesets"
+  value       = module.private_dns.dns_forwarding_rulesets
+}
+
+output "all_dns_records" {
+  description = "All DNS records created"
+  value = {
+    a_records     = module.private_dns.a_records
+    aaaa_records  = module.private_dns.aaaa_records
+    cname_records = module.private_dns.cname_records
+    mx_records    = module.private_dns.mx_records
+    srv_records   = module.private_dns.srv_records
+    txt_records   = module.private_dns.txt_records
+  }
+}

--- a/azure-private-dns/examples/basic/main.tf
+++ b/azure-private-dns/examples/basic/main.tf
@@ -1,0 +1,85 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.42.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+# Create a virtual network for demonstration
+resource "azurerm_resource_group" "example" {
+  name     = "rg-private-dns-basic-example"
+  location = "West Europe"
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "vnet-private-dns-example"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  tags = {
+    Environment = "Development"
+    Project     = "Private-DNS-Example"
+  }
+}
+
+# Basic Private DNS Zone module usage
+module "private_dns" {
+  source = "../../"
+
+  # Basic configuration
+  location                = azurerm_resource_group.example.location
+  resource_group_name     = azurerm_resource_group.example.name
+  create_resource_group   = false
+  private_dns_zone_name   = "example.internal"
+
+  # Virtual network links
+  virtual_network_links = {
+    "primary-vnet" = {
+      virtual_network_id   = azurerm_virtual_network.example.id
+      registration_enabled = true
+    }
+  }
+
+  # Basic DNS records
+  a_records = {
+    "web-server" = {
+      name    = "web"
+      ttl     = 300
+      records = ["10.0.1.10"]
+    }
+    "api-server" = {
+      name    = "api"
+      ttl     = 300
+      records = ["10.0.1.20"]
+    }
+  }
+
+  cname_records = {
+    "www-alias" = {
+      name   = "www"
+      ttl    = 300
+      record = "web.example.internal"
+    }
+  }
+
+  # Naming convention
+  naming_convention = {
+    prefix = ["example"]
+    suffix = ["basic"]
+  }
+
+  tags = {
+    Environment = "Development"
+    Project     = "Private-DNS-Example"
+    Example     = "Basic"
+  }
+}

--- a/azure-private-dns/examples/basic/main.tf
+++ b/azure-private-dns/examples/basic/main.tf
@@ -36,10 +36,10 @@ module "private_dns" {
   source = "../../"
 
   # Basic configuration
-  location                = azurerm_resource_group.example.location
-  resource_group_name     = azurerm_resource_group.example.name
-  create_resource_group   = false
-  private_dns_zone_name   = "example.internal"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  create_resource_group = false
+  private_dns_zone_name = "example.internal"
 
   # Virtual network links
   virtual_network_links = {

--- a/azure-private-dns/examples/basic/outputs.tf
+++ b/azure-private-dns/examples/basic/outputs.tf
@@ -1,0 +1,24 @@
+output "private_dns_zone_id" {
+  description = "The ID of the Private DNS Zone"
+  value       = module.private_dns.private_dns_zone_id
+}
+
+output "private_dns_zone_name" {
+  description = "The name of the Private DNS Zone"
+  value       = module.private_dns.private_dns_zone_name
+}
+
+output "virtual_network_links" {
+  description = "The virtual network links"
+  value       = module.private_dns.virtual_network_links
+}
+
+output "a_records" {
+  description = "The A records created"
+  value       = module.private_dns.a_records
+}
+
+output "cname_records" {
+  description = "The CNAME records created"
+  value       = module.private_dns.cname_records
+}

--- a/azure-private-dns/examples/basic/outputs.tf
+++ b/azure-private-dns/examples/basic/outputs.tf
@@ -8,17 +8,17 @@ output "private_dns_zone_name" {
   value       = module.private_dns.private_dns_zone_name
 }
 
-output "virtual_network_links" {
-  description = "The virtual network links"
-  value       = module.private_dns.virtual_network_links
+output "virtual_network_link_ids" {
+  description = "The virtual network link IDs"
+  value       = module.private_dns.virtual_network_link_ids
 }
 
-output "a_records" {
-  description = "The A records created"
-  value       = module.private_dns.a_records
+output "a_record_ids" {
+  description = "The A record IDs created"
+  value       = module.private_dns.a_record_ids
 }
 
-output "cname_records" {
-  description = "The CNAME records created"
-  value       = module.private_dns.cname_records
+output "cname_record_ids" {
+  description = "The CNAME record IDs created"
+  value       = module.private_dns.cname_record_ids
 }

--- a/azure-private-dns/outputs.tf
+++ b/azure-private-dns/outputs.tf
@@ -106,13 +106,7 @@ output "txt_record_ids" {
   }
 }
 
-# Private Endpoint DNS Zone Group Outputs
-output "private_endpoint_dns_zone_group_ids" {
-  description = "Map of private endpoint DNS zone group names to their IDs"
-  value = {
-    for name, group in azurerm_private_dns_zone_group.main : name => group.id
-  }
-}
+# Note: Private endpoint DNS zone groups removed - not supported in current AzureRM provider version
 
 # DNS Resolver Outputs
 output "dns_resolver_id" {

--- a/azure-private-dns/variables.tf
+++ b/azure-private-dns/variables.tf
@@ -135,19 +135,8 @@ variable "txt_records" {
   default = {}
 }
 
-# Private Endpoint DNS Zone Groups
-variable "private_endpoint_dns_zone_groups" {
-  description = "Map of private endpoint DNS zone groups to create"
-  type = map(object({
-    name                = string
-    private_endpoint_id = string
-    private_dns_zone_configs = list(object({
-      name                = string
-      private_dns_zone_id = optional(string)
-    }))
-  }))
-  default = {}
-}
+# Note: Private Endpoint DNS Zone Groups are not supported in current AzureRM provider version
+# These should be configured directly on the private endpoint resource
 
 # DNS Resolver Configuration
 variable "enable_dns_resolver" {


### PR DESCRIPTION
## Overview
This PR fixes critical validation issues in the `azure-private-dns` module that were causing the release workflow to fail after the merge of PR #9.

## Problem
The release workflow was failing during the "Pre-Release Validation (azure-private-dns)" job with the following errors:
- **Unsupported naming attributes**: `private_dns_zone_virtual_network_link` and `private_dns_resolver` are not supported by the Azure naming module v0.4.2
- **Invalid resource type**: `azurerm_private_dns_zone_group` is not supported by the AzureRM provider v4.42.0

## Solution
### 1. Fixed Naming Module Dependencies
- Replaced `module.naming.private_dns_zone_virtual_network_link.name` with static naming pattern `vnet-link-${each.key}`
- Replaced `module.naming.private_dns_resolver.name` with static pattern `dns-resolver-${var.project_name}-${var.environment}`
- Replaced other unsupported naming attributes with similar static patterns

### 2. Removed Unsupported Resources
- Removed `azurerm_private_dns_zone_group` resource (not supported in AzureRM provider v4.42.0)
- Removed corresponding `private_endpoint_dns_zone_groups` variable
- Updated outputs to remove references to removed resources
- Added comments explaining why these features are not available

### 3. Maintained Functionality
- All other DNS functionality remains intact (A, AAAA, CNAME, MX, PTR, SRV, TXT records)
- DNS resolver and forwarding rulesets still work with static naming
- Virtual network links and registration features preserved

## Testing
- ✅ `terraform init` succeeds
- ✅ `terraform validate` passes
- ✅ Module structure is simplified but maintains core functionality

## Impact
- **Fixes**: Release workflow validation failures in azure-private-dns module
- **Maintains**: All core Private DNS zone and record management functionality
- **Removes**: Advanced private endpoint DNS zone group features (can be added later when AzureRM provider supports them)

## Files Changed
- `azure-private-dns/main.tf` - Fixed unsupported naming attributes and removed unsupported resources
- `azure-private-dns/variables.tf` - Removed unsupported variable definitions
- `azure-private-dns/outputs.tf` - Updated outputs to match new implementation

This change ensures the release workflow can proceed with validated Terraform modules and resolves the blocking validation failures.